### PR TITLE
Import plus rapide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'parallel'
 gem 'rest-client'
-gem 'bulk_insert'
+gem 'postgres-copy'
+gem 'composite_primary_keys'
+gem 'parallel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,6 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
-    bulk_insert (1.7.0)
-      activerecord (>= 3.2.0)
     byebug (11.0.1)
     capybara (3.25.0)
       addressable
@@ -74,6 +72,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    composite_primary_keys (11.2.0)
+      activerecord (~> 5.2.1)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     domain_name (0.5.20190701)
@@ -116,6 +116,10 @@ GEM
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     pg (1.1.4)
+    postgres-copy (1.4.1)
+      activerecord (>= 5.1)
+      pg (>= 0.17)
+      responders
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -152,6 +156,9 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.5.1)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -216,15 +223,16 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
-  bulk_insert
   byebug
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  composite_primary_keys
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   parallel
   pg (>= 0.18, < 2.0)
+  postgres-copy
   puma (~> 3.11)
   rails (~> 5.2.3)
   rest-client

--- a/app/models/auction.rb
+++ b/app/models/auction.rb
@@ -1,4 +1,8 @@
 class Auction < ApplicationRecord
+  self.primary_key = :auc, :realm_id
+
+  acts_as_copy_target
+
   # has_many :auction_infos, dependent: :destroy
 
   # def as_json(options = {})

--- a/bin/convert_auctions_json_to_csv.rb
+++ b/bin/convert_auctions_json_to_csv.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+# require File.expand_path('../../config/environment', __FILE__)
+
+auctions_file_path = ARGV[2]
+output_file = auctions_file_path.gsub(/json$/, 'csv.temp')
+_, realm_region, realm_id = File.basename(auctions_file_path).gsub('.json', '').split("-")
+created_at = Time.now
+
+File.open auctions_file_path do |auctions_file|
+  auctions = JSON.load(auctions_file)['auctions']
+
+  File.open(output_file, "wb+") do |output_file|
+    auctions.each do |auction|
+      output_file.puts [
+        auction['auc'],
+        realm_id.to_i,
+        auction['item'],
+        auction['owner'],
+        realm_region,
+        auction['ownerRealm'],
+        auction['quantity'],
+        auction['buyout'],
+        auction['bid'],
+        auction['timeLeft'],
+        created_at,
+        created_at
+      ].map { |value| value.kind_of?(Numeric) ? value : "\"#{value.to_s.gsub('"', '""')}\"" }.join(",")
+    end
+  end
+end
+
+File.rename output_file, output_file.gsub(".temp", "")
+
+

--- a/db/migrate/20190902163821_set_auc_as_auction_primary_key.rb
+++ b/db/migrate/20190902163821_set_auc_as_auction_primary_key.rb
@@ -1,0 +1,8 @@
+class SetAucAsAuctionPrimaryKey < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :auctions, :id, :bigint, index: true, unique: true
+    remove_index :auctions, :auc
+    add_index :auctions, :auc, unique: true
+    execute "ALTER TABLE auctions ADD PRIMARY KEY (auc);"
+  end
+end

--- a/db/migrate/20190902184347_add_index_to_auctions_regions.rb
+++ b/db/migrate/20190902184347_add_index_to_auctions_regions.rb
@@ -1,0 +1,5 @@
+class AddIndexToAuctionsRegions < ActiveRecord::Migration[5.2]
+  def change
+    add_index :auctions, :region
+  end
+end

--- a/db/migrate/20190902193347_add_composite_id_to_auctions.rb
+++ b/db/migrate/20190902193347_add_composite_id_to_auctions.rb
@@ -1,0 +1,12 @@
+class AddCompositeIdToAuctions < ActiveRecord::Migration[5.2]
+  def up
+    add_belongs_to :auctions, :realm
+    execute "ALTER TABLE auctions DROP CONSTRAINT auctions_pkey;"
+    execute "ALTER TABLE auctions ADD PRIMARY KEY (auc, realm_id);"
+  end
+
+  def down
+    remove_belongs_to :auctions, :realm
+    execute "ALTER TABLE auctions ADD PRIMARY KEY (auc);"
+  end
+end

--- a/db/migrate/20190902194811_remove_uniqueness_on_auc_index.rb
+++ b/db/migrate/20190902194811_remove_uniqueness_on_auc_index.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenessOnAucIndex < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :auctions, :auc
+    add_index :auctions, :auc
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_141332) do
+ActiveRecord::Schema.define(version: 2019_09_02_194811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "auctions", force: :cascade do |t|
-    t.bigint "auc"
+  create_table "auctions", primary_key: ["auc", "realm_id"], force: :cascade do |t|
+    t.bigint "auc", null: false
     t.bigint "item"
     t.string "owner"
     t.string "region"
-    t.string "owner_realm"
     t.integer "quantity"
     t.bigint "buyout"
     t.bigint "bid"
     t.string "time_left"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "owner_realm"
+    t.bigint "realm_id", null: false
     t.index ["auc"], name: "index_auctions_on_auc"
+    t.index ["realm_id"], name: "index_auctions_on_realm_id"
+    t.index ["region"], name: "index_auctions_on_region"
   end
 
   create_table "items", force: :cascade do |t|

--- a/lib/tasks/auctions.rake
+++ b/lib/tasks/auctions.rake
@@ -30,6 +30,7 @@ namespace :auctions do
       auction_urls_file = "#{wdir}/urls.txt"
 
       # On télecharge tout avec aria2
+      raise "aria2 must be installed" if `which ariaw2c`.blank?
       Thread.new do
         loop do
           File.open(auction_urls_file, "wb") do |f|
@@ -37,7 +38,7 @@ namespace :auctions do
           end
 
           # l'option -j permet de mettre une limite haute aux nombre de téléchargement simultané, ca peut valoir le coup de tester d'autres valeurs
-          system("aria2c -q -j 32 -m 0 -d #{wdir} --on-download-complete #{Rails.root}/bin/convert_auctions_json_to_csv.rb -i #{auction_urls_file}")
+          system("aria2c -q -j 8 -m 0 -d #{wdir} --on-download-complete #{Rails.root}/bin/convert_auctions_json_to_csv.rb -i #{auction_urls_file}")
 
           if $? != 0 # Si le programme s'est fini avec une erreur on fait le compte des fichiers qui n'ont pas été dl et on les redemandes, sinon on break
             auction_urls = auction_urls.select do |auction_url, output|

--- a/lib/tasks/auctions.rake
+++ b/lib/tasks/auctions.rake
@@ -14,7 +14,7 @@ namespace :auctions do
       # c'est pas super propre de faire passer de l'information en utilisant un nom de fichier, mais j'ai pas d'autres idées
       auction_urls = realms.map do |realm|
         begin
-          print "\rgetting auctions file url for ".ljust(60) + "#{realm.region}/#{realm.name}".ljust(60)
+          print "\rgetting auctions file url for ".ljust(40) + "#{realm.region}/#{realm.name}".ljust(60)
           response = RestClient.get "https://#{realm.region}.api.blizzard.com/wow/auction/data/#{realm.slug}?locale=en_GB&access_token=#{access_token}"
           [ JSON.parse(response.body)['files'][0]['url'], "auctions-#{realm.region}-#{realm.id}.json" ]
         rescue => error
@@ -30,7 +30,7 @@ namespace :auctions do
       auction_urls_file = "#{wdir}/urls.txt"
 
       # On télecharge tout avec aria2
-      raise "aria2 must be installed" if `which ariaw2c`.blank?
+      raise "aria2 must be installed" if `which aria2c`.blank?
       Thread.new do
         loop do
           File.open(auction_urls_file, "wb") do |f|
@@ -58,7 +58,7 @@ namespace :auctions do
           File.exists?("#{wdir}/#{output.gsub(/json$/, 'csv')}")
         end
 
-        print "\rgenerating auctions CSVs".ljust(60) + "#{csv_files.size}/#{auction_urls.count}".ljust(60)
+        print "\rgenerating auctions CSVs".ljust(40) + "#{csv_files.size}/#{auction_urls.count}".ljust(60)
         break if csv_files.size == auction_urls.size
       end
       puts
@@ -71,7 +71,7 @@ namespace :auctions do
         system("cat #{auctions_csv} >> #{csv_file}")
         File.unlink auctions_csv
 
-        print "\rbundling".ljust(60) + "#{index + 1}/#{auction_urls.count}".ljust(60)
+        print "\rbundling".ljust(40) + "#{index + 1}/#{auction_urls.count}".ljust(60)
       end
       puts
 

--- a/lib/tasks/common.rb
+++ b/lib/tasks/common.rb
@@ -26,7 +26,7 @@ def app_auth(region, client_id, client_secret)
       exit 1
     end
     
-    print "getting access token... "
+    print "getting access token...".ljust(40)
     access_token = blizz_auth(region, client_id, client_secret)
     if access_token.empty?
       exit 2


### PR DESCRIPTION
Pas mal de choses !

En pratique plutôt que de faire les royaumes un par un je fais tout par gros block : 

* d'abord on récupère toutes les URL des JSON
* ensuite on utilise un soft qui s'appel `aria2` (qu'il faut installer, mais c'est dans les paquets Ubuntu) pour s'occuper de télécharger les fichiers en parallèle
* ce soft est capable d'appeler une commande à chaque fin de téléchargement, on appel un script `bin/convert_auctions_json_to_csv.rb` qui s'occupe de convertir les JSON en CSV (en même temps que les autres téléchargement se poursuivent)
* ensuite on bundle tout dans un gros CSV et on fait un copie dans Postgres

Je me suis un peu cherché sur quoi indexer ou pas dans la table, du coup il y a quelques migrations dont certaines en revert d'autres (mais c'est pas très grave), il faudra sans doute supprimer toutes les auctions avant de migrate. Apparement certains auc pouvait être en double (une histoire de royaume connecté je crois, je suis pas sûr), du coup j'ai changé la clé primaire de la table auctions pour utiliser ce qu'on appel une clé composite (une clé qui est formé de plusieurs champ, en l'occurence `auc` et `realm_id` dans ce cas là) et ca marche pas mal.

En terme de temps j'arrive à 20 minutes pour mon Macbook et 11 minutes pour ma plus grosse machine, je n'ai pas testé sur un serveur.